### PR TITLE
Stop massive spams from one line 

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -25,21 +25,22 @@ bot.on('message', function(msg)
     {
         msg.reply('You best not be talking about me, you little punk.');
     }
-    if(msg.content.startsWith(eyes + "covfefe"))
+    else if(msg.content.startsWith(eyes + "covfefe"))
     {
         msg.reply('Reeee covfefe is dead');
     }
-    if(smsg.search(/ftl station/i) >= 0)
+    else if(smsg.search(/ftl station/i) >= 0)
     {
         msg.reply('Reeee its a ship not a station get it right');
     }
-    if(msg.content.startsWith(eyes + "help"))
+    else if(msg.content.startsWith(eyes + "help"))
     {
         msg.reply('Commands are started with the eyes emote, followed by the command name. You ain\'t getting any more help out of me, you fuck.');
     }
-    if(smsg.search(/(could|would|should|may|might) +of +(?!course)/i) >= 0) {
+    else if(smsg.search(/(could|would|should|may|might) +of +(?!course)/i) >= 0) {
         msg.reply('It\'s could HAVE or would HAVE, never could *of* or would *of*');
     }
+    //The important stuff
     if(msg.content.startsWith(eyes + "status"))
     {
         http2byond({'ip':'ftl13.com','port':'7777','topic':'?status'}, function(body, err) {


### PR DESCRIPTION
msg:
covfefe is dead, Astraeus. You should of known, you are the AI for FTL station.
rsp:
You best not be talking about me, you little punk.
Reeee covfefe is dead
Reeee its a ship not a station get it right
It's could HAVE or would HAVE, never could of or would of

The spam was funny the first time but the meme is dead.
Now it just responds with the first thing it finds, except for status calls and admin calls which are unaffected.
Please test this first I dont know how to javascript.