### PR TITLE
Stops the bot from announcing prs opened or closed by itself

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -191,7 +191,7 @@ function handleHttpRequest(request, response) {
                 }
             }
             if(queryObj.pull_request) {
-                if(queryObj.action == 'opened' || queryObj.action == 'closed' || queryObj.action == 'reopened') {
+                if((queryObj.action == 'opened' || queryObj.action == 'closed' || queryObj.action == 'reopened') && queryObj.pull_request.user.login != 'FTL13-Bot') {
                     if(queryObj.action == 'closed' && queryObj.pull_request.merged) {
                         queryObj.action = 'merged';
                         var date = new Date()


### PR DESCRIPTION
The title says it all. This is so the mirror prs don't get announced all the time primarily.